### PR TITLE
Add product subfacades

### DIFF
--- a/src/Facades/Product.php
+++ b/src/Facades/Product.php
@@ -2,6 +2,10 @@
 
 namespace Gildsmith\Contract\Facades;
 
+use Gildsmith\Contract\Facades\Product\Attribute as AttributeFacade;
+use Gildsmith\Contract\Facades\Product\AttributeValue as AttributeValueFacade;
+use Gildsmith\Contract\Facades\Product\Blueprint as BlueprintFacade;
+use Gildsmith\Contract\Facades\Product\ProductCollection as ProductCollectionFacade;
 use Gildsmith\Contract\Product\ProductInterface;
 use Gildsmith\Support\Utils\ValidationRules;
 use Illuminate\Support\Collection;
@@ -14,6 +18,26 @@ use Illuminate\Support\Collection;
  */
 interface Product
 {
+    /**
+     * Access the attribute management facade.
+     */
+    public function attribute(): AttributeFacade;
+
+    /**
+     * Access the attribute value management facade.
+     */
+    public function attributeValue(): AttributeValueFacade;
+
+    /**
+     * Access the blueprint management facade.
+     */
+    public function blueprint(): BlueprintFacade;
+
+    /**
+     * Access the product collection management facade.
+     */
+    public function collection(): ProductCollectionFacade;
+
     /**
      * Retrieve a product by its unique code.
      *

--- a/src/Facades/Product/Attribute.php
+++ b/src/Facades/Product/Attribute.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gildsmith\Contract\Facades\Product;
+
+use Gildsmith\Contract\Product\AttributeInterface;
+use Gildsmith\Support\Utils\ValidationRules;
+use Illuminate\Support\Collection;
+
+/**
+ * Facade for managing product attributes.
+ */
+interface Attribute
+{
+    /**
+     * Retrieve an attribute by its unique code.
+     *
+     * Trashed attributes are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     */
+    public function find(string $code, bool $withTrashed = false): ?AttributeInterface;
+
+    /**
+     * Retrieve all attributes.
+     *
+     * Trashed attributes are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     *
+     * @return Collection<int, AttributeInterface>
+     */
+    public function all(bool $withTrashed = false): Collection;
+
+    /**
+     * Retrieve only soft-deleted attributes.
+     *
+     * @return Collection<int, AttributeInterface>
+     */
+    public function trashed(): Collection;
+
+    /**
+     * Create a new attribute using the provided data array.
+     *
+     * The array must contain a valid, unique `code`.
+     *
+     * @see ValidationRules::CODE
+     */
+    public function create(array $data): AttributeInterface;
+
+    /**
+     * Update an existing attribute by its code. The code itself
+     * is immutable and must not be included in $data.
+     */
+    public function update(string $code, array $data): AttributeInterface;
+
+    /**
+     * Create or update an attribute based on the given code.
+     *
+     * If an attribute exists, it will be updated;
+     * otherwise a new one is created.
+     */
+    public function updateOrCreate(string $code, array $data): AttributeInterface;
+
+    /**
+     * Delete an attribute by its code. If $force is true,
+     * the attribute will be permanently deleted.
+     */
+    public function delete(string $code, bool $force = false): bool;
+
+    /**
+     * Restore a soft-deleted attribute by its code.
+     */
+    public function restore(string $code): bool;
+}

--- a/src/Facades/Product/AttributeValue.php
+++ b/src/Facades/Product/AttributeValue.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gildsmith\Contract\Facades\Product;
+
+use Gildsmith\Contract\Product\AttributeValueInterface;
+use Gildsmith\Support\Utils\ValidationRules;
+use Illuminate\Support\Collection;
+
+/**
+ * Facade for managing attribute values.
+ */
+interface AttributeValue
+{
+    /**
+     * Retrieve an attribute value by its unique code.
+     *
+     * Trashed values are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     */
+    public function find(string $code, bool $withTrashed = false): ?AttributeValueInterface;
+
+    /**
+     * Retrieve all attribute values.
+     *
+     * Trashed values are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     *
+     * @return Collection<int, AttributeValueInterface>
+     */
+    public function all(bool $withTrashed = false): Collection;
+
+    /**
+     * Retrieve only soft-deleted attribute values.
+     *
+     * @return Collection<int, AttributeValueInterface>
+     */
+    public function trashed(): Collection;
+
+    /**
+     * Create a new attribute value using the provided data array.
+     *
+     * The array must contain a valid, unique `code`.
+     *
+     * @see ValidationRules::CODE
+     */
+    public function create(array $data): AttributeValueInterface;
+
+    /**
+     * Update an existing attribute value by its code. The code itself
+     * is immutable and must not be included in $data.
+     */
+    public function update(string $code, array $data): AttributeValueInterface;
+
+    /**
+     * Create or update an attribute value based on the given code.
+     *
+     * If a value exists, it will be updated;
+     * otherwise a new one is created.
+     */
+    public function updateOrCreate(string $code, array $data): AttributeValueInterface;
+
+    /**
+     * Delete an attribute value by its code. If $force is true,
+     * the value will be permanently deleted.
+     */
+    public function delete(string $code, bool $force = false): bool;
+
+    /**
+     * Restore a soft-deleted attribute value by its code.
+     */
+    public function restore(string $code): bool;
+}

--- a/src/Facades/Product/Blueprint.php
+++ b/src/Facades/Product/Blueprint.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gildsmith\Contract\Facades\Product;
+
+use Gildsmith\Contract\Product\BlueprintInterface;
+use Gildsmith\Support\Utils\ValidationRules;
+use Illuminate\Support\Collection;
+
+/**
+ * Facade for managing product blueprints.
+ */
+interface Blueprint
+{
+    /**
+     * Retrieve a blueprint by its unique code.
+     *
+     * Trashed blueprints are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     */
+    public function find(string $code, bool $withTrashed = false): ?BlueprintInterface;
+
+    /**
+     * Retrieve all blueprints.
+     *
+     * Trashed blueprints are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     *
+     * @return Collection<int, BlueprintInterface>
+     */
+    public function all(bool $withTrashed = false): Collection;
+
+    /**
+     * Retrieve only soft-deleted blueprints.
+     *
+     * @return Collection<int, BlueprintInterface>
+     */
+    public function trashed(): Collection;
+
+    /**
+     * Create a new blueprint using the provided data array.
+     *
+     * The array must contain a valid, unique `code`.
+     *
+     * @see ValidationRules::CODE
+     */
+    public function create(array $data): BlueprintInterface;
+
+    /**
+     * Update an existing blueprint by its code. The code itself
+     * is immutable and must not be included in $data.
+     */
+    public function update(string $code, array $data): BlueprintInterface;
+
+    /**
+     * Create or update a blueprint based on the given code.
+     *
+     * If a blueprint exists, it will be updated;
+     * otherwise a new one is created.
+     */
+    public function updateOrCreate(string $code, array $data): BlueprintInterface;
+
+    /**
+     * Delete a blueprint by its code. If $force is true,
+     * the blueprint will be permanently deleted.
+     */
+    public function delete(string $code, bool $force = false): bool;
+
+    /**
+     * Restore a soft-deleted blueprint by its code.
+     */
+    public function restore(string $code): bool;
+}

--- a/src/Facades/Product/ProductCollection.php
+++ b/src/Facades/Product/ProductCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Gildsmith\Contract\Facades\Product;
+
+use Gildsmith\Contract\Product\ProductCollectionInterface;
+use Gildsmith\Support\Utils\ValidationRules;
+use Illuminate\Support\Collection;
+
+/**
+ * Facade for managing product collections.
+ */
+interface ProductCollection
+{
+    /**
+     * Retrieve a product collection by its unique code.
+     *
+     * Trashed collections are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     */
+    public function find(string $code, bool $withTrashed = false): ?ProductCollectionInterface;
+
+    /**
+     * Retrieve all product collections.
+     *
+     * Trashed collections are excluded by default. Set
+     * $withTrashed to true to include them in the search.
+     *
+     * @return Collection<int, ProductCollectionInterface>
+     */
+    public function all(bool $withTrashed = false): Collection;
+
+    /**
+     * Retrieve only soft-deleted product collections.
+     *
+     * @return Collection<int, ProductCollectionInterface>
+     */
+    public function trashed(): Collection;
+
+    /**
+     * Create a new product collection using the provided data array.
+     *
+     * The array must contain a valid, unique `code`.
+     *
+     * @see ValidationRules::CODE
+     */
+    public function create(array $data): ProductCollectionInterface;
+
+    /**
+     * Update an existing product collection by its code. The code itself
+     * is immutable and must not be included in $data.
+     */
+    public function update(string $code, array $data): ProductCollectionInterface;
+
+    /**
+     * Create or update a product collection based on the given code.
+     *
+     * If a collection exists, it will be updated;
+     * otherwise a new one is created.
+     */
+    public function updateOrCreate(string $code, array $data): ProductCollectionInterface;
+
+    /**
+     * Delete a product collection by its code. If $force is true,
+     * the collection will be permanently deleted.
+     */
+    public function delete(string $code, bool $force = false): bool;
+
+    /**
+     * Restore a soft-deleted product collection by its code.
+     */
+    public function restore(string $code): bool;
+}


### PR DESCRIPTION
## Summary
- add dedicated facades for attributes, attribute values, blueprints, and product collections
- expose attribute, attribute value, blueprint, and collection subfacades through the Product facade

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/pint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688da71042648320b962e3fabbd8e21b