### PR TITLE
feat: introduce generic CRUD and trashable facades

### DIFF
--- a/src/Facades/CrudFacade.php
+++ b/src/Facades/CrudFacade.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Gildsmith\Contract\Facades;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Generic CRUD facade interface.
+ *
+ * @template TModel
+ */
+interface CrudFacade
+{
+    /**
+     * Retrieve a model by its unique code.
+     *
+     * @return TModel|null
+     */
+    public function find(string $code);
+
+    /**
+     * Retrieve all models.
+     *
+     * @return Collection<int, TModel>
+     */
+    public function all(): Collection;
+
+    /**
+     * Create a new model using the provided data array.
+     *
+     * @return TModel
+     */
+    public function create(array $data);
+
+    /**
+     * Update an existing model by its code.
+     *
+     * @return TModel
+     */
+    public function update(string $code, array $data);
+
+    /**
+     * Create or update a model based on the given code.
+     *
+     * @return TModel
+     */
+    public function updateOrCreate(string $code, array $data);
+
+    /**
+     * Delete a model by its code.
+     */
+    public function delete(string $code): bool;
+}

--- a/src/Facades/Product.php
+++ b/src/Facades/Product.php
@@ -7,16 +7,17 @@ use Gildsmith\Contract\Facades\Product\AttributeValue as AttributeValueFacade;
 use Gildsmith\Contract\Facades\Product\Blueprint as BlueprintFacade;
 use Gildsmith\Contract\Facades\Product\ProductCollection as ProductCollectionFacade;
 use Gildsmith\Contract\Product\ProductInterface;
-use Gildsmith\Support\Utils\ValidationRules;
-use Illuminate\Support\Collection;
+use Gildsmith\Contract\Facades\TrashableFacade;
 
 /**
  * Product Facade serves as a programmatic interface for managing products.
  *
  * It mimics an internal API, allowing consumers to perform product
  * operations without knowledge of the underlying implementation.
+ *
+ * @extends TrashableFacade<ProductInterface>
  */
-interface Product
+interface Product extends TrashableFacade
 {
     /**
      * Access the attribute management facade.
@@ -38,63 +39,5 @@ interface Product
      */
     public function collection(): ProductCollectionFacade;
 
-    /**
-     * Retrieve a product by its unique code.
-     *
-     * Trashed products are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     */
-    public function find(string $code, bool $withTrashed = false): ?ProductInterface;
-
-    /**
-     * Retrieve all products.
-     *
-     * Trashed products are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     *
-     * @return Collection<int, ProductInterface>
-     */
-    public function all(bool $withTrashed = false): Collection;
-
-    /**
-     * Retrieve only soft-deleted products.
-     *
-     * @return Collection<int, ProductInterface>
-     */
-    public function trashed(): Collection;
-
-    /**
-     * Create a new product using the provided data array.
-     *
-     * The array must contain a valid, unique `code`. Additional fields
-     * will depend on system configuration and blueprint expectations.
-     *
-     * @see ValidationRules::CODE
-     */
-    public function create(array $data): ProductInterface;
-
-    /**
-     * Update an existing product by its code. The code itself
-     * is immutable and must not be included in $data.
-     */
-    public function update(string $code, array $data): ProductInterface;
-
-    /**
-     * Create or update a product based on the given code.
-     *
-     * If a product exists, it will be updated;
-     * otherwise a new one is created.
-     */
-    public function updateOrCreate(string $code, array $data): ProductInterface;
-
-    /**
-     * Delete a product by its code. If $force is true,
-     * the product will be permanently deleted.
-     */
-    public function delete(string $code, bool $force = false): bool;
-
-    /**
-     * Restore a soft-deleted product by its code.
-     */
-    public function restore(string $code): bool;
+    // CRUD operations inherited from TrashableFacade
 }

--- a/src/Facades/Product/Attribute.php
+++ b/src/Facades/Product/Attribute.php
@@ -2,71 +2,14 @@
 
 namespace Gildsmith\Contract\Facades\Product;
 
+use Gildsmith\Contract\Facades\TrashableFacade;
 use Gildsmith\Contract\Product\AttributeInterface;
-use Gildsmith\Support\Utils\ValidationRules;
-use Illuminate\Support\Collection;
 
 /**
  * Facade for managing product attributes.
+ *
+ * @extends TrashableFacade<AttributeInterface>
  */
-interface Attribute
+interface Attribute extends TrashableFacade
 {
-    /**
-     * Retrieve an attribute by its unique code.
-     *
-     * Trashed attributes are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     */
-    public function find(string $code, bool $withTrashed = false): ?AttributeInterface;
-
-    /**
-     * Retrieve all attributes.
-     *
-     * Trashed attributes are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     *
-     * @return Collection<int, AttributeInterface>
-     */
-    public function all(bool $withTrashed = false): Collection;
-
-    /**
-     * Retrieve only soft-deleted attributes.
-     *
-     * @return Collection<int, AttributeInterface>
-     */
-    public function trashed(): Collection;
-
-    /**
-     * Create a new attribute using the provided data array.
-     *
-     * The array must contain a valid, unique `code`.
-     *
-     * @see ValidationRules::CODE
-     */
-    public function create(array $data): AttributeInterface;
-
-    /**
-     * Update an existing attribute by its code. The code itself
-     * is immutable and must not be included in $data.
-     */
-    public function update(string $code, array $data): AttributeInterface;
-
-    /**
-     * Create or update an attribute based on the given code.
-     *
-     * If an attribute exists, it will be updated;
-     * otherwise a new one is created.
-     */
-    public function updateOrCreate(string $code, array $data): AttributeInterface;
-
-    /**
-     * Delete an attribute by its code. If $force is true,
-     * the attribute will be permanently deleted.
-     */
-    public function delete(string $code, bool $force = false): bool;
-
-    /**
-     * Restore a soft-deleted attribute by its code.
-     */
-    public function restore(string $code): bool;
 }

--- a/src/Facades/Product/AttributeValue.php
+++ b/src/Facades/Product/AttributeValue.php
@@ -2,71 +2,14 @@
 
 namespace Gildsmith\Contract\Facades\Product;
 
+use Gildsmith\Contract\Facades\TrashableFacade;
 use Gildsmith\Contract\Product\AttributeValueInterface;
-use Gildsmith\Support\Utils\ValidationRules;
-use Illuminate\Support\Collection;
 
 /**
  * Facade for managing attribute values.
+ *
+ * @extends TrashableFacade<AttributeValueInterface>
  */
-interface AttributeValue
+interface AttributeValue extends TrashableFacade
 {
-    /**
-     * Retrieve an attribute value by its unique code.
-     *
-     * Trashed values are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     */
-    public function find(string $code, bool $withTrashed = false): ?AttributeValueInterface;
-
-    /**
-     * Retrieve all attribute values.
-     *
-     * Trashed values are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     *
-     * @return Collection<int, AttributeValueInterface>
-     */
-    public function all(bool $withTrashed = false): Collection;
-
-    /**
-     * Retrieve only soft-deleted attribute values.
-     *
-     * @return Collection<int, AttributeValueInterface>
-     */
-    public function trashed(): Collection;
-
-    /**
-     * Create a new attribute value using the provided data array.
-     *
-     * The array must contain a valid, unique `code`.
-     *
-     * @see ValidationRules::CODE
-     */
-    public function create(array $data): AttributeValueInterface;
-
-    /**
-     * Update an existing attribute value by its code. The code itself
-     * is immutable and must not be included in $data.
-     */
-    public function update(string $code, array $data): AttributeValueInterface;
-
-    /**
-     * Create or update an attribute value based on the given code.
-     *
-     * If a value exists, it will be updated;
-     * otherwise a new one is created.
-     */
-    public function updateOrCreate(string $code, array $data): AttributeValueInterface;
-
-    /**
-     * Delete an attribute value by its code. If $force is true,
-     * the value will be permanently deleted.
-     */
-    public function delete(string $code, bool $force = false): bool;
-
-    /**
-     * Restore a soft-deleted attribute value by its code.
-     */
-    public function restore(string $code): bool;
 }

--- a/src/Facades/Product/Blueprint.php
+++ b/src/Facades/Product/Blueprint.php
@@ -2,71 +2,14 @@
 
 namespace Gildsmith\Contract\Facades\Product;
 
+use Gildsmith\Contract\Facades\TrashableFacade;
 use Gildsmith\Contract\Product\BlueprintInterface;
-use Gildsmith\Support\Utils\ValidationRules;
-use Illuminate\Support\Collection;
 
 /**
  * Facade for managing product blueprints.
+ *
+ * @extends TrashableFacade<BlueprintInterface>
  */
-interface Blueprint
+interface Blueprint extends TrashableFacade
 {
-    /**
-     * Retrieve a blueprint by its unique code.
-     *
-     * Trashed blueprints are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     */
-    public function find(string $code, bool $withTrashed = false): ?BlueprintInterface;
-
-    /**
-     * Retrieve all blueprints.
-     *
-     * Trashed blueprints are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     *
-     * @return Collection<int, BlueprintInterface>
-     */
-    public function all(bool $withTrashed = false): Collection;
-
-    /**
-     * Retrieve only soft-deleted blueprints.
-     *
-     * @return Collection<int, BlueprintInterface>
-     */
-    public function trashed(): Collection;
-
-    /**
-     * Create a new blueprint using the provided data array.
-     *
-     * The array must contain a valid, unique `code`.
-     *
-     * @see ValidationRules::CODE
-     */
-    public function create(array $data): BlueprintInterface;
-
-    /**
-     * Update an existing blueprint by its code. The code itself
-     * is immutable and must not be included in $data.
-     */
-    public function update(string $code, array $data): BlueprintInterface;
-
-    /**
-     * Create or update a blueprint based on the given code.
-     *
-     * If a blueprint exists, it will be updated;
-     * otherwise a new one is created.
-     */
-    public function updateOrCreate(string $code, array $data): BlueprintInterface;
-
-    /**
-     * Delete a blueprint by its code. If $force is true,
-     * the blueprint will be permanently deleted.
-     */
-    public function delete(string $code, bool $force = false): bool;
-
-    /**
-     * Restore a soft-deleted blueprint by its code.
-     */
-    public function restore(string $code): bool;
 }

--- a/src/Facades/Product/ProductCollection.php
+++ b/src/Facades/Product/ProductCollection.php
@@ -2,71 +2,14 @@
 
 namespace Gildsmith\Contract\Facades\Product;
 
+use Gildsmith\Contract\Facades\TrashableFacade;
 use Gildsmith\Contract\Product\ProductCollectionInterface;
-use Gildsmith\Support\Utils\ValidationRules;
-use Illuminate\Support\Collection;
 
 /**
  * Facade for managing product collections.
+ *
+ * @extends TrashableFacade<ProductCollectionInterface>
  */
-interface ProductCollection
+interface ProductCollection extends TrashableFacade
 {
-    /**
-     * Retrieve a product collection by its unique code.
-     *
-     * Trashed collections are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     */
-    public function find(string $code, bool $withTrashed = false): ?ProductCollectionInterface;
-
-    /**
-     * Retrieve all product collections.
-     *
-     * Trashed collections are excluded by default. Set
-     * $withTrashed to true to include them in the search.
-     *
-     * @return Collection<int, ProductCollectionInterface>
-     */
-    public function all(bool $withTrashed = false): Collection;
-
-    /**
-     * Retrieve only soft-deleted product collections.
-     *
-     * @return Collection<int, ProductCollectionInterface>
-     */
-    public function trashed(): Collection;
-
-    /**
-     * Create a new product collection using the provided data array.
-     *
-     * The array must contain a valid, unique `code`.
-     *
-     * @see ValidationRules::CODE
-     */
-    public function create(array $data): ProductCollectionInterface;
-
-    /**
-     * Update an existing product collection by its code. The code itself
-     * is immutable and must not be included in $data.
-     */
-    public function update(string $code, array $data): ProductCollectionInterface;
-
-    /**
-     * Create or update a product collection based on the given code.
-     *
-     * If a collection exists, it will be updated;
-     * otherwise a new one is created.
-     */
-    public function updateOrCreate(string $code, array $data): ProductCollectionInterface;
-
-    /**
-     * Delete a product collection by its code. If $force is true,
-     * the collection will be permanently deleted.
-     */
-    public function delete(string $code, bool $force = false): bool;
-
-    /**
-     * Restore a soft-deleted product collection by its code.
-     */
-    public function restore(string $code): bool;
 }

--- a/src/Facades/TrashableFacade.php
+++ b/src/Facades/TrashableFacade.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Gildsmith\Contract\Facades;
+
+use Illuminate\Support\Collection;
+
+/**
+ * CRUD facade with soft-delete support.
+ *
+ * @template TModel
+ * @extends CrudFacade<TModel>
+ */
+interface TrashableFacade extends CrudFacade
+{
+    /**
+     * Retrieve a model by code, including soft-deleted models.
+     *
+     * @return TModel|null
+     */
+    public function findIncludingTrashed(string $code);
+
+    /**
+     * Retrieve all models including soft-deleted ones.
+     *
+     * @return Collection<int, TModel>
+     */
+    public function allIncludingTrashed(): Collection;
+
+    /**
+     * Retrieve only soft-deleted models.
+     *
+     * @return Collection<int, TModel>
+     */
+    public function trashed(): Collection;
+
+    /**
+     * Restore a soft-deleted model by its code.
+     */
+    public function restore(string $code): bool;
+
+    /**
+     * Permanently delete a model by its code.
+     */
+    public function forceDelete(string $code): bool;
+}


### PR DESCRIPTION
## Summary
- add generic `CrudFacade` interface for core CRUD operations
- add `TrashableFacade` extending CRUD with soft-delete helpers
- refactor product-related facades to extend the new contracts

## Testing
- `php -l src/Facades/CrudFacade.php src/Facades/TrashableFacade.php src/Facades/Product.php src/Facades/Product/Attribute.php src/Facades/Product/AttributeValue.php src/Facades/Product/Blueprint.php src/Facades/Product/ProductCollection.php`
- `composer install -n` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688df59ad67c8320a4da17faf3c0a257